### PR TITLE
bug: fixed #14

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,21 @@
+=================
+API documentation
+=================
+
+The Inelastica package consists of a variety of sub packages enabling
+different routines for electronic structure calculations.
+
+.. toctree::
+   :maxdepth: 2
+
+   api-gen/Inelastica
+
+.. autosummary::
+   :toctree: api-gen
+   :hidden:
+
+   Inelastica.*
+
+
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,8 @@ exclude_patterns = ['build', '**/setupegg.py', '**/setup.rst', '**/tests', '**.i
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# A list of ignored prefixes for module index sorting.
+modindex_common_prefix = ['Inelastica.']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,11 +65,23 @@ Indices
 
    install
    examples
-   cite
-   publications
    faq
    more
 
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Publications
+
+   cite
+   publications
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Reference documentation
+
+   api
 
 
 .. |buildstatus| image:: https://travis-ci.org/tfrederiksen/inelastica.svg

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -1,7 +1,7 @@
 .. _publications:
 
-Publications
-============
+Publications using Inelastica
+=============================
 
 List of research publication where `Inelastica <docs_>`_ was used.
 

--- a/docs/run.sh
+++ b/docs/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -rf api-gen
 make clean
 sphinx-apidoc -fMeET -o api-gen ../Inelastica ../Inelastica/**/setup.py
 make html


### PR DESCRIPTION
To fully fix #14 more changes to the submodules headers and documentation
are necessary. I.e. the documentation should be in the `__init__` files
and in the headers of the files.
This takes more time to fix.