### PR TITLE
Fixed 'py2' divisions to integer division

### DIFF
--- a/Inelastica/MakeGeom.py
+++ b/Inelastica/MakeGeom.py
@@ -571,7 +571,7 @@ class Geom(object):
         hw = ncfile.variables['hw'][modeindex]
         U = ncfile.variables['U'][modeindex]
         print('MakeGeom.StretchAlongEigenvector: Stretching %.3e Ang along mode #%i (hw = %.4f eV).'%(displacement, modeindex, hw))
-        d = len(U)/3
+        d = len(U) // 3
         U = N.reshape(U, (d, 3))
         firstdynatom = int(ncfile.variables['DynamicAtoms'][0]-1)
         for i in range(d):

--- a/Inelastica/Phonons.py
+++ b/Inelastica/Phonons.py
@@ -343,7 +343,7 @@ class OSrun(object):
                 thisHS.setkpoint(kpoint, atype=atype)
                 S = thisHS.S
                 del thisHS
-                nao = len(S)/2
+                nao = len(S) // 2
                 S0 = S[0:nao, 0:nao].copy()
                 dmat = S[0:nao, nao:nao*2].copy()
                 if file.endswith('_1.onlyS'):
@@ -364,10 +364,10 @@ class OSrun(object):
                 xyz = N.array(SIO.Getxyz(onlySdir+'/RUN_%i.fdf'%i))
                 #for j in range(1, len(xyz)):
                 #    thisd = min(thisd, (N.dot(xyz[0]-xyz[j], xyz[0]-xyz[j]))**.5)
-                j = len(xyz)/2
+                j = len(xyz) // 2
                 v = xyz[0]-xyz[j]
                 thisd = N.dot(v, v)**.5
-                Displ[(i-1)/2, 1-2*(i%2)] = thisd
+                Displ[(i-1) // 2, 1-2*(i % 2)] = thisd
                 print('Phonons.GetOnlyS: OnlyS-displacement (min) = %.5f Ang'%thisd)
             # Construct dS array
             self.S0 = S0
@@ -499,7 +499,7 @@ class DynamicalMatrix(object):
         Udisp = U.copy()
         for i in range(3*dyn):
             # Eigenvectors after division by sqrt(mass)
-            Udisp[:, i] = U[:, i]/self.Masses[i/3]**.5
+            Udisp[:, i] = U[:, i] / self.Masses[i // 3]**.5
 
         # Compute displacement vectors scaled for the characteristic length
         Ucl = N.empty_like(U)
@@ -507,7 +507,7 @@ class DynamicalMatrix(object):
             for i in range(3*dyn):
                 # Eigenvectors after multiplication by characteristic length
                 if hw[j] > 0:
-                    Ucl[j, i] = U[j, i]*(1./(self.Masses[i/3]*(hw[j]/(2*PC.Rydberg2eV)))**.5)
+                    Ucl[j, i] = U[j, i] * (1. / (self.Masses[i // 3] * abs(hw[j] / (2*PC.Rydberg2eV)))**.5)
                 else:
                     # Characteristic length not defined for non-postive frequency
                     Ucl[j, i] = U[j, i]*0.0

--- a/Inelastica/STM.py
+++ b/Inelastica/STM.py
@@ -219,8 +219,8 @@ def main(options):
     for ii in range(nokpts):
         file = NC.Dataset('./'+options.DestDir+'/'+str(ii)+'/FDcurr'+str(ii)+'.nc', 'r')
         ikSTMimage = file.variables['Curr'][:, :]/(nokpts)
-        STMimage += ShiftOrigin(ikSTMimage, dim1/2, dim2/2)
-        tmpSTM[ii*dim1:(ii+1)*dim1, :] = ShiftOrigin(ikSTMimage, dim1/2, dim2/2)
+        STMimage += ShiftOrigin(ikSTMimage, dim1 // 2, dim2 // 2)
+        tmpSTM[ii*dim1:(ii+1)*dim1, :] = ShiftOrigin(ikSTMimage, dim1 // 2, dim2 // 2)
     STMimagekpt = N.zeros((dim1*options.Nk1, dim2*options.Nk2))
     for ii in range(options.Nk1):
         for jj in range(options.Nk2):

--- a/Inelastica/io/siesta.py
+++ b/Inelastica/io/siesta.py
@@ -352,7 +352,7 @@ def WriteMKLFile(filename, atomnumber, xyz, freq, vec, FCfirst, FClast):
     mklfile.write('$END\n')
     if len(freq) > 0:
         mklfile.write('$FREQ\n')
-        for i in range(len(freq)/3):
+        for i in range(len(freq) // 3):
             mklfile.write('C1 C1 C1\n')
             # Write frequencies
             line = ''

--- a/Inelastica/physics/mesh.py
+++ b/Inelastica/physics/mesh.py
@@ -134,10 +134,10 @@ class kmesh(object):
         """
         print(' ... Applying inversion symmetry (the simple way)')
         # No brute force (and therefore terribly slow) pairing here
-        indx = [[ii, 2] for ii in range(self.NNk/2, self.NNk)] # Keep the last half of the k-points with double weight
-        k0 = self.k[self.NNk/2]
+        indx = [[ii, 2] for ii in range(self.NNk // 2, self.NNk)]  # Keep the last half of the k-points with double weight
+        k0 = self.k[self.NNk // 2]
         if N.dot(k0, k0) == 0: # Gamma in the kptlist
-            indx[0] = [self.NNk/2, 1] # lower weight to one
+            indx[0] = [self.NNk // 2, 1] # lower weight to one
         indx, weight = N.array([ii[0] for ii in indx]), N.array([ii[1] for ii in indx])
         kpts, wgts = self.k[indx], self.w[:, indx]*weight
         self.k = kpts

--- a/Inelastica/utils/bands2xmgr
+++ b/Inelastica/utils/bands2xmgr
@@ -176,7 +176,7 @@ if __name__ == '__main__':
 
     if spins==2:
         # Splitting eigenvalues and DOS
-        eval = (len(EvsK[0])-1)/2
+        eval = (len(EvsK[0])-1) // 2
         upEvsK = EvsK[:, :eval+1].copy()
         downEvsK = EvsK[:, eval:].copy()
         downEvsK[:, 0] = EvsK[:, 0]


### PR DESCRIPTION
I got some exceptions from indexing while using Inelastica with python3. I fixed these and also everywhere else where I found that divisions were performed on variables that were indices.