### PR TITLE
Copy ChemicalSpeciesLabel in generated struct-fdfs

### DIFF
--- a/Inelastica/SetupRuns.py
+++ b/Inelastica/SetupRuns.py
@@ -30,6 +30,7 @@ import netCDF4 as NC4
 import numpy as N
 import Inelastica.MakeGeom as MG
 import Inelastica.physics.constants as PC
+from Inelastica.io.siesta import copy_chemical_info
 
 
 # -----------------------------------------------------------------------------------------------------
@@ -186,6 +187,9 @@ def SetupFCrun(CGrun, newFCrun, FCfirst, FClast, displacement=0.02,
     geom.writeFDF(newFCrun+'/STRUCT.fdf')
     geom.writeXYZ(newFCrun+'/STRUCT.xyz')
     geom.writeXYZ(newFCrun+'/STRUCT2.xyz', rep=[2, 2, 2])
+    if os.path.isfile(CGrun+"/STRUCT.fdf"):
+        copy_chemical_info(CGrun+"/STRUCT.fdf", newFCrun+"/STRUCT.fdf")
+
     # Prepend lines to RUN.fdf
     for elm in glob.glob(newFCrun+'/RUN.fdf'):
         if os.path.isfile(elm):
@@ -268,6 +272,9 @@ def SetupOSrun(CGrun, newOSrun, displacement=0.02,
     BuildOSstruct(infile, newOSrun+'/STRUCT_6.fdf', axes=[2], direction=[1], displacement=displacement)
     structfiles = ['STRUCT_1.fdf', 'STRUCT_2.fdf', 'STRUCT_3.fdf',
                    'STRUCT_4.fdf', 'STRUCT_5.fdf', 'STRUCT_6.fdf']
+    if os.path.isfile(CGrun+"/STRUCT.fdf"):
+        for struct in structfiles:
+            copy_chemical_info(CGrun+"/STRUCT.fdf", newOSrun+"/"+struct)
     inputfiles = ['RUN_1.fdf', 'RUN_2.fdf', 'RUN_3.fdf', 'RUN_4.fdf', 'RUN_5.fdf', 'RUN_6.fdf']
     # Write input files
     for i, inputfile in enumerate(inputfiles):

--- a/Inelastica/io/siesta.py
+++ b/Inelastica/io/siesta.py
@@ -518,6 +518,24 @@ def WriteFDFFileZmat(filename, vectors, speciesnumber, atomnumber, xyz, first=0,
     zmatfile.write('constraints\n')
     zmatfile.write('%endblock Zmatrix\n')
 
+
+def copy_chemical_info(from_p, to_p):
+    # In some cases (eg. when exporting SISL), ChemicalSpeciesLabel is also in
+    # the structure file, but it is not in the .XV file and not handled by
+    # MG.Geom, so this function allows copying the info from one fdf to another.
+    with open(from_p, "r") as f:
+        f0 = f.readlines()
+    with open(to_p, "a") as f:
+        f.writelines(filter(lambda l: l.startswith("NumberOfSpecies"), f0))
+        try:
+            start = f0.index("%block ChemicalSpeciesLabel\n")
+            end = f0.index("%endblock ChemicalSpeciesLabel\n")
+            f.writelines(f0[start:end+1])
+        except ValueError as e:
+            # There was no ChemicalSpeciesLabel in the in-file
+            pass
+
+
 #--------------------------------------------------------------------------------
 # Read systemlabel.STRUCT_OUT files
 


### PR DESCRIPTION
This makes Inelastica copy over all the relevant information in generated fdf's, if it was in the input STRUCT.fdf file. This is the case if one uses structures from eg. sisl.