### PR TITLE
Corrected characteristic length calculation

### DIFF
--- a/Inelastica/Phonons.py
+++ b/Inelastica/Phonons.py
@@ -502,15 +502,11 @@ class DynamicalMatrix(object):
             Udisp[:, i] = U[:, i] / self.Masses[i // 3]**.5
 
         # Compute displacement vectors scaled for the characteristic length
-        Ucl = N.empty_like(U)
-        for j in range(3*dyn):
-            for i in range(3*dyn):
-                # Eigenvectors after multiplication by characteristic length
-                if hw[j] > 0:
-                    Ucl[j, i] = U[j, i] * (1. / (self.Masses[i // 3] * abs(hw[j] / (2*PC.Rydberg2eV)))**.5)
-                else:
-                    # Characteristic length not defined for non-postive frequency
-                    Ucl[j, i] = U[j, i]*0.0
+        Ucl = N.zeros_like(U)
+        Ucl[hw > 0, :] = PC.hbar2SI / N.sqrt(
+            N.array(self.Masses).repeat(3).reshape(1, -1) * PC.amu2kg
+            * hw[hw > 0].reshape(-1, 1) * PC.eV2Joule
+            ) * 1e10 * U[hw > 0, :]
 
         # Expand vectors to full geometry
         UU = N.zeros((len(hw), self.geom.natoms, 3), N.complex)


### PR DESCRIPTION
The characteristic length is `sqrt(hbar/(m*w))`. I think that the previous code had gotten the units mixed up? In any case, the last line in the code below should return True, which it will with this PR. Essentially the force constant matrix is the hessian matrix for the total energy, so if we displace by the characteristic length via `E=1/2 <u|FC|u>`, the energy should change by the characteristic energy (which is `hw/2`).

```python
from Inelastica import Phonons
import numpy as np; from pathlib import Path
dyns=np.load("../eph_rse.npy")  # or however you get the dynamic atoms
fdfs = [str(p) for p in Path().glob("atm*/RUN.fdf")]  # or wherever your fcruns are
D = Phonons.DynamicalMatrix(fdfs ,DynamicAtoms=list(dyns+1))
D.SetMasses()
D.ComputePhononModes(D.mean)
fcmat = D.mean.real[:,:,dyns,:].reshape(72, 72)  # I know I have 24*3=72 'springs'
fcmat += fcmat.T
fcmat /= 2
assert np.allclose(D.hw[D.hw > 0], np.diag(D.Ucl.dot(fcmat).dot(D.Ucl.T)).real[D.hw > 0])
```