### PR TITLE
Added tile function to geometry, much faster than 'repeteGeom'

### DIFF
--- a/Inelastica/scripts/geom2zmat
+++ b/Inelastica/scripts/geom2zmat
@@ -30,6 +30,6 @@ print('Converting %s to %s with repetition'%(args.GIN, args.GOUT), rep)
 g = MG.Geom(args.GIN)
 for i in range(3):
     if rep[i]>1:
-        g.repeteGeom(g.pbc[i], rep=rep[i])
+        g.tile(g.pbc[i], rep=rep[i])
         g.pbc[i]=g.pbc[i]*rep[i]
 g.writeFDFZmat(args.GOUT, args.first, args.last)


### PR DESCRIPTION
The new function is equivalent, but it runs faster. Runtime is not a huge issue for any of the affected inelastica commands, but as I recall, some 'simple' things were taking a bit too long for comfort (fast enough that one waits for them to complete - slow enough to be annoying) and I realized that this simple optimization would make everything run faster. I guess the difference only shows for larger structures.