### PR TITLE
Added ability to use jinja2 templates for pbs scripts

### DIFF
--- a/Inelastica/templating.py
+++ b/Inelastica/templating.py
@@ -1,0 +1,13 @@
+from jinja2 import Environment, FileSystemLoader
+
+
+j2 = Environment(loader=FileSystemLoader(["./", "/"]))
+
+
+def _add_fdffloat_filter():
+    def fdffloat(x, fmt="{:.8f}"):
+        return fmt.format(x)
+    j2.filters["fdffloat"] = fdffloat
+
+
+_add_fdffloat_filter()


### PR DESCRIPTION
I used this to create submission templates that contained expressions like `{{hours or 0}}:{{minutes or 0}}`, ie. for typing default parameters into a template. It looks for templates in the current working directory (or if you specify a path from root then there). 

Jinja can do a lot of things which is probably overkill too, but I felt the need for a bit more than string substitution and then this was just the easy solution.